### PR TITLE
Fix git branch reference in demo helper script

### DIFF
--- a/container/falcon-container-terraform/demo
+++ b/container/falcon-container-terraform/demo
@@ -33,7 +33,7 @@ EOF
 
 # Main demo up function
 demo_up() {
-    BRANCH=master
+    BRANCH=main
     GITHUB_ORG=CrowdStrike
     
     [ -d ~/cloud-azure ] || (cd "$HOME" && git clone --branch $BRANCH --depth 1 https://github.com/$GITHUB_ORG/cloud-azure)


### PR DESCRIPTION
This helper script was referencing an old branch name and needed to be changed.